### PR TITLE
fix time flicker

### DIFF
--- a/steps.go
+++ b/steps.go
@@ -97,7 +97,7 @@ func (m Steps) Update(msg tea.Msg) (Steps, tea.Cmd) { //nolint:cyclop
 	switch msg := msg.(type) {
 	case tickMsg:
 		if m.steps[m.currentStep].state == Started {
-			m.steps[m.currentStep].duration = time.Since(m.steps[m.currentStep].startedAt).Round(time.Millisecond)
+			m.steps[m.currentStep].duration = time.Since(m.steps[m.currentStep].startedAt)
 
 			return m, tick()
 		}
@@ -147,6 +147,18 @@ func (m Steps) Update(msg tea.Msg) (Steps, tea.Cmd) { //nolint:cyclop
 	return m, nil
 }
 
+func roundDuration(duration time.Duration) string {
+	if duration.Milliseconds() < 1000 {
+		return duration.Round(time.Millisecond).String()
+	}
+
+	if duration.Seconds() < 60 {
+		return fmt.Sprintf("%.3fs", duration.Seconds())
+	}
+
+	return duration.Round(time.Second).String()
+}
+
 func (m Steps) ViewOne(index int) string {
 	var (
 		space   string
@@ -166,7 +178,7 @@ func (m Steps) ViewOne(index int) string {
 	if step.state == Skipped {
 		lastly = "(skipped)"
 	} else {
-		lastly = step.duration.Round(time.Millisecond).String()
+		lastly = roundDuration(step.duration)
 	}
 
 	if m.viewportWidth > 0 {

--- a/steps_test.go
+++ b/steps_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -194,4 +195,24 @@ func TestView(t *testing.T) {
 	steps.View()
 	steps.viewportWidth = 100
 	steps.View()
+}
+
+func TestRoundDuration(t *testing.T) {
+	t.Parallel()
+
+	if roundDuration(time.Millisecond*900) != "900ms" {
+		t.Fatalf("Expected sub-second format to be milliseconds")
+	}
+
+	if roundDuration(time.Millisecond*1900) != "1.900s" {
+		t.Fatalf("Expected sub-minute format to include milliseconds")
+	}
+
+	if roundDuration(time.Millisecond*60900) != "1m1s" {
+		t.Fatalf("Expected > minute format to round to the second")
+	}
+
+	if roundDuration(time.Millisecond*60990) != "1m1s" {
+		t.Fatalf("Expected > minute format to round to the second")
+	}
 }


### PR DESCRIPTION
```
1.107s
1.11s
1.1s
1s
```

causes flickering when rounded with `time.Millisecond`. Instead, figure out the round value based on the duration.